### PR TITLE
CASMCMS-7388: Transitioning to Github and Artifactory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@
 #
 # (MIT License)
 
-FROM arti.dev.cray.com/baseos-docker-master-local/alpine:3.13.5
+FROM artifactory.algol60.net/docker.io/alpine:3.13
 WORKDIR /app
 EXPOSE 69/udp
 VOLUME /var/lib/tftpboot

--- a/install_cms_meta_tools.sh
+++ b/install_cms_meta_tools.sh
@@ -22,30 +22,69 @@
 #
 # (MIT License)
 
-REL=cmt-1.0
-CMT_RPMS_URL=https://arti.dev.cray.com/artifactory/internal-rpm-master-local/release/$REL/sle15_sp2/noarch/
+# This file is based on the file of the same name in the sample_scripts 
+# directory in the cms-meta-tools repo. If you have problems with it, 
+# there may be a newer version of the file in that repo which corrects
+# the problem.
 
-# Find latest cms-meta-tools RPM in our chosen release (0.1)
+# The following two variables determine which versions of the cms-meta-tools RPM will be considered
+REL_MAJOR=2
+REL_MINOR=0
+CMT_RPMS_URL=https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/cms-meta-tools/noarch/
+RETRY_MINUTES=10
+
+# Find latest cms-meta-tools RPM in our chosen release
 function cmt-rpm-url
 {
-    curl -s $CMT_RPMS_URL | 
+    local tmpfile
+    local stop
+    
+    tmpfile=/tmp/.cmt-rpm-url.$$.$RANDOM.$RANDOM.$RANDOM.tmp
+    let stop=SECONDS+60*RETRY_MINUTES
+
+    while [ true ]; do
+        if ! curl -is $CMT_RPMS_URL > $tmpfile ; then
+            echo "ERROR: curl command failed or error writing to $tmpfile" 1>&2
+            return 1
+        elif head -1 $tmpfile | grep -wq "5[0-9][0-9]" ; then
+            if [ $SECONDS -lt $stop ]; then
+                echo "WARNING: Temporary server error returned by $CMT_RPMS_URL. Will retry query in 30 seconds" 1>&2
+            else
+                echo "ERROR: Still receiving server errors after retrying for over $RETRY_MINUTES minutes" 1>&2
+                return 1
+            fi
+            sleep 30
+            continue
+        fi
+        break
+    done
+
+    if ! grep -Eqo "cms-meta-tools-[0-9][0-9]*[.][0-9][0-9]*[.][0-9][0-9]*-[0-9][0-9]*[.]noarch[.]rpm" $tmpfile ; then
+        echo "ERROR: No cms-meta-tools RPMs found in $CMT_RPMS_URL" 1>&2
+        cat $tmpfile 1>&2
+        return 1
+    elif ! grep -Eqo "cms-meta-tools-${REL_MAJOR}[.]${REL_MINOR}[.][0-9][0-9]*-[0-9][0-9]*[.]noarch[.]rpm" $tmpfile ; then
+        echo "ERROR: No cms-meta-tools RPMs with version ${REL_MAJOR}.${REL_MINOR} found in $CMT_RPMS_URL" 1>&2
+        cat $tmpfile 1>&2
+        return 1
+    fi
+    cat $tmpfile | 
         # Filter out everything except the RPM names
-        grep -Eo "cms-meta-tools-[0-9][0-9]*[.][0-9][0-9]*[.][0-9][0-9]*-[0-9][0-9]*_[0-9a-f][0-9a-f]*[.]noarch[.]rpm" | 
-        # Extract the version and build date and print those numbers followed by the full URL to the RPM
-        sed "s#^cms-meta-tools-\([0-9][0-9]*\)[.]\([0-9][0-9]*\)[.]\([0-9][0-9]*\)-\([0-9][0-9]*\)_.*\$#\1 \2 \3 \4 $CMT_RPMS_URL\0#" |
+        grep -Eo "cms-meta-tools-${REL_MAJOR}[.]${REL_MINOR}[.][0-9][0-9]*-[0-9][0-9]*[.]noarch[.]rpm" | 
+        # Extract the version and print those numbers followed by the full URL to the RPM
+        sed "s#^cms-meta-tools-[0-9][0-9]*[.][0-9][0-9]*[.]\([0-9][0-9]*\)-\([0-9][0-9]*\)[.].*\$#\1 \2 $CMT_RPMS_URL\0#" |
         # Sort numerically by those fields, higher numbers first 
-        sort -u -n -r -t" " -k1 -k2 -k3 -k4 | 
+        sort -u -n -r -t" " -k1 -k2 | 
         # Take the first one and print only the RPM URL
         head -1 | awk -F" " '{ print $NF }'
+    return 0
 }
 
-RPM_URL=$(cmt-rpm-url)
-if [ -n "$RPM_URL" ]; then
-    echo "cms-meta-tools RPM: $RPM_URL"
-else
-    echo "Unable to find latest cms-meta-tools RPM in $CMT_RPMS_URL" 1>&2
+if ! RPM_URL=$(cmt-rpm-url) || [ -z "${RPM_URL}" ]; then
+    echo "ERROR: Unable to find latest cms-metal-tools RPM" 1>&2
     exit 1
 fi
+echo "cms-meta-tools RPM: $RPM_URL"
 
 TRGDIR=$(pwd)/cms_meta_tools
 mkdir -pv "$TRGDIR" || exit 1

--- a/kubernetes/cray-tftp-pvc/README.md
+++ b/kubernetes/cray-tftp-pvc/README.md
@@ -1,3 +1,3 @@
 # cray-tftp Helm chart
 
-In most cases the resources here should be left at their defaults. Should you need to add additional resources to your helm chart, you have the ability to do so. If you find that you're making changes that might be applicable to other Cray services, you're encouraged to submit a pull request to [the base service chart](https://stash.us.cray.com/projects/CLOUD/repos/cray-charts/browse/stable/cray-service).
+In most cases the resources here should be left at their defaults. Should you need to add additional resources to your helm chart, you have the ability to do so. If you find that you're making changes that might be applicable to other Cray services, you're encouraged to submit a pull request to [the base service chart](https://github.com/Cray-HPE/base-charts/tree/master/kubernetes/cray-service).

--- a/kubernetes/cray-tftp-pvc/values.yaml
+++ b/kubernetes/cray-tftp-pvc/values.yaml
@@ -1,4 +1,4 @@
-# Please refer to https://stash.us.cray.com/projects/CLOUD/repos/cray-charts/browse/stable/cray-service/values.yaml?at=refs%2Fheads%2Fmaster
+# Please refer to https://github.com/Cray-HPE/base-charts/blob/master/kubernetes/cray-service/values.yaml
 # for more info on values you can set/override
 # Note that cray-service.containers[*].image and cray-service.initContainers[*].image map values are one of the only structures that
 # differ from the standard kubernetes container spec:

--- a/kubernetes/cray-tftp/README.md
+++ b/kubernetes/cray-tftp/README.md
@@ -1,3 +1,3 @@
 # cray-tftp Helm chart
 
-In most cases the resources here should be left at their defaults. Should you need to add additional resources to your helm chart, you have the ability to do so. If you find that you're making changes that might be applicable to other Cray services, you're encouraged to submit a pull request to [the base service chart](https://stash.us.cray.com/projects/CLOUD/repos/cray-charts/browse/stable/cray-service).
+In most cases the resources here should be left at their defaults. Should you need to add additional resources to your helm chart, you have the ability to do so. If you find that you're making changes that might be applicable to other Cray services, you're encouraged to submit a pull request to [the base service chart](https://github.com/Cray-HPE/base-charts/tree/master/kubernetes/cray-service).

--- a/kubernetes/cray-tftp/values.yaml
+++ b/kubernetes/cray-tftp/values.yaml
@@ -1,4 +1,4 @@
-# Please refer to https://stash.us.cray.com/projects/CLOUD/repos/cray-charts/browse/stable/cray-service/values.yaml?at=refs%2Fheads%2Fmaster
+# Please refer to https://github.com/Cray-HPE/base-charts/blob/master/kubernetes/cray-service/values.yaml
 # for more info on values you can set/override
 # Note that cray-service.containers[*].image and cray-service.initContainers[*].image map values are one of the only structures that
 # differ from the standard kubernetes container spec:

--- a/kubernetes/cray-tftpd-ipxe/values.yaml
+++ b/kubernetes/cray-tftpd-ipxe/values.yaml
@@ -1,4 +1,4 @@
-# Please refer to https://stash.us.cray.com/projects/CLOUD/repos/cray-charts/browse/stable/cray-service/values.yaml?at=refs%2Fheads%2Fmaster
+# Please refer to https://github.com/Cray-HPE/base-charts/blob/master/kubernetes/cray-service/values.yaml
 # for more info on values you can set/override
 # Note that cray-service.containers[*].image and cray-service.initContainers[*].image map values are one of the only structures that
 # differ from the standard kubernetes container spec:

--- a/update_versions.conf
+++ b/update_versions.conf
@@ -1,8 +1,11 @@
 #tag: version tag string to be replaced (optional -- if unspecified @VERSION@ is assumed)
-#sourcefile: file to read actual version from (optional -- if unspecified, .version is assumed)
-#targetfile: file in which to have version tags replaced
+#sourcefile: file to obtain the actual version from (optional -- if unspecified, .version is assumed)
+#            If this file is executable, it will be executed and the output will be used as the version string.
+#            Otherwise it will be read and its contents will be used as the version string.
+#targetfile: file in which to have version tags replaced. When this line is reached, the replacement
+#            action is performed on this file.
 #
-#Multiples of these lines are allowed. A given line is in effect until another line overrides it.
+#Multiples of any of these lines are allowed. A given line is in effect until another line overrides it.
 #Example:
 #tag: @TAG1@
 #sourcefile: path/to/version1.txt


### PR DESCRIPTION
As part of the transition to Github CMS is pushing its artifacts to its
own artifactory. This commit references a base Docker image from this
new artifactory location algol60. It also changes URLs to point to
Github rather than Stash.

A newer version of the install_cms_meta_tools.sh script was used.