### PR TITLE
CASMCMS-7388: Clone the cms-meta-tools

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -21,6 +21,14 @@ pipeline {
     }
 
     stages {
+       stage("Clone cms_meta_tools repo") {
+            steps {
+                withCredentials([gitUsernamePassword(credentialsId: 'jenkins-algol60-cray-hpe-github-integration')]) {
+                    sh "make clone_cms_meta_tools"
+                }
+            }
+        }
+	
         stage("Build Prep") {
             steps {
                 sh "make build_prep"

--- a/Makefile
+++ b/Makefile
@@ -27,19 +27,23 @@ CHART_VERSION ?= $(VERSION)
 
 HELM_UNITTEST_IMAGE ?= quintush/helm-unittest:3.3.0-0.2.5
 
-all : build_prep lint image chart
-
+all : clone_cms_meta_tools build_prep lint image chart
 chart: chart_setup chart_tftp chart_tftp_pvc chart_tftpd_ipxe
 
 chart_tftp: chart_tftp_package chart_tftp_test
 chart_tftp_pvc: chart_tftp_pvc_package chart_tftp_pvc_test
 chart_tftpd_ipxe: chart_tftpd_ipxe_package chart_tftpd_ipxe_test
 
+# If you wish to perform a local build, you will need to clone or copy the contents of the
+# cms_meta_tools repo to ./cms_meta_tools
+clone_cms_meta_tools:
+		git clone --depth 1 --no-single-branch https://github.com/Cray-HPE/cms-meta-tools.git ./cms_meta_tools
+
 build_prep:
-		./runBuildPrep.sh
+		./cms_meta_tools/scripts/runBuildPrep.sh
 
 lint:
-		./runLint.sh
+		./cms_meta_tools/scripts/runLint.sh
 
 image:
 		docker build --pull ${DOCKER_ARGS} --tag '${DOCKER_NAME}:${VERSION}' .


### PR DESCRIPTION
Clone the cms-meta-tools directory to gain access to these scripts,
straight from the source. This eliminates installing them via RPM
into the build directory. It is cleaner and simpler.