### PR TITLE
Update base image to CVE patched location.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@
 #
 # Dockerfile for CMS tftpd service
 
-FROM artifactory.algol60.net/docker.io/alpine:3.13 as base
+FROM artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3.15 as base
 WORKDIR /app
 EXPOSE 69/udp
 VOLUME /var/lib/tftpboot


### PR DESCRIPTION
## Summary and Scope

Update the base image to alpine:3.15 and pull from the location that is being patched nightly for CVE remediations.

## Issues and Related PRs

* Resolves [CASMCMS-7958](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7958)

## Testing
### Tested on:
  * `Wasp`

### Test description:

Installed new version via loftsman, ran the ct test, reverted, then ran the ct test again.  All looks good.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Y
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This is a low risk change as it is not relying on any features of a particular version of alpine.

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
