### PR TITLE
CASMTRIAGE-4761: Switch to modern modprobe version with compression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- Upgraded kmod pkg within the built image to handle kernels requiring compressed kmods
 - Add root override to cray-tftp-ipxe helm chart
 - Enabled building of unstable artifacts
 - Updated header of update_versions.conf to reflect new tool options

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ VOLUME /var/lib/tftpboot
 RUN apk add --upgrade --no-cache apk-tools &&  \
 	apk update && \
 	apk add --no-cache \
-		syslog-ng tftp-hpa && \
+		syslog-ng tftp-hpa kmod && \
 	apk -U upgrade --no-cache && \
     mkdir -p /var/lib/tftpboot
 COPY syslog-ng.conf /etc/syslog-ng/

--- a/kubernetes/cray-tftp/Chart.yaml
+++ b/kubernetes/cray-tftp/Chart.yaml
@@ -33,8 +33,6 @@ dependencies:
   version: "^7.0.0"
   repository: "https://artifactory.algol60.net/artifactory/csm-helm-charts/"
 maintainers:
-- name: rkleinman-hpe
-  email: randy.kleinman@hpe.com
 - name: jsl-hpe
   email: joel.landsteiner@hpe.com
 - name: jsollom-hpe
@@ -44,6 +42,4 @@ annotations:
   artifacthub.io/images: |
     - name: cray-tftpd
       image: artifactory.algol60.net/csm-docker/S-T-A-B-L-E/cray-tftpd:0.0.0-image
-    - name: alpine
-      image: artifactory.algol60.net/docker.io/library/alpine:3
   artifacthub.io/license: MIT

--- a/kubernetes/cray-tftp/templates/nf_nat_tftp.yaml
+++ b/kubernetes/cray-tftp/templates/nf_nat_tftp.yaml
@@ -64,7 +64,7 @@ spec:
           requests:
             cpu: ".1"
             memory: "20M"
-        image: "artifactory.algol60.net/docker.io/library/alpine:3"
+        image: "artifactory.algol60.net/csm-docker/S-T-A-B-L-E/cray-tftpd:0.0.0-image"
         imagePullPolicy: Always
         command: ["/bin/ash"]
         args: ["-c", "modprobe nf_nat_tftp; while true; do sleep 999999; done"]

--- a/kubernetes/cray-tftpd-ipxe/Chart.yaml
+++ b/kubernetes/cray-tftpd-ipxe/Chart.yaml
@@ -33,8 +33,6 @@ dependencies:
   version: "^7.0.0"
   repository: "https://artifactory.algol60.net/artifactory/csm-helm-charts/"
 maintainers:
-- name: rkleinman-hpe
-  email: randy.kleinman@hpe.com
 - name: jsl-hpe
   email: joel.landsteiner@hpe.com
 - name: jsollom-hpe

--- a/kubernetes/cray-tftpd-ipxe/templates/nf_nat_tftp.yaml
+++ b/kubernetes/cray-tftpd-ipxe/templates/nf_nat_tftp.yaml
@@ -64,7 +64,7 @@ spec:
           requests:
             cpu: ".1"
             memory: "20M"
-        image: "artifactory.algol60.net/docker.io/library/alpine:3"
+        image: "artifactory.algol60.net/csm-docker/S-T-A-B-L-E/cray-tftpd:0.0.0-image"
         imagePullPolicy: Always
         command: ["/bin/ash"]
         args: ["-c", "modprobe nf_nat_tftp; while true; do sleep 999999; done"]

--- a/update_versions.conf
+++ b/update_versions.conf
@@ -29,7 +29,9 @@ targetfile: kubernetes/cray-tftp-pvc/Chart.yaml
 sourcefile: .docker_version
 tag: 0.0.0-image
 targetfile: kubernetes/cray-tftp/Chart.yaml
+targetfile: kubernetes/cray-tftp/templates/nf_nat_tftp.yaml
 targetfile: kubernetes/cray-tftpd-ipxe/Chart.yaml
+targetfile: kubernetes/cray-tftpd-ipxe/templates/nf_nat_tftp.yaml
 targetfile: kubernetes/cray-tftp-pvc/Chart.yaml
 
 # The following file does not exist in the repo as a static file
@@ -43,5 +45,8 @@ sourcefile-novalidate: .stable
 tag: S-T-A-B-L-E
 targetfile: kubernetes/cray-tftp/Chart.yaml
 targetfile: kubernetes/cray-tftp/values.yaml
+targetfile: kubernetes/cray-tftp/templates/nf_nat_tftp.yaml
 targetfile: kubernetes/cray-tftpd-ipxe/Chart.yaml
 targetfile: kubernetes/cray-tftpd-ipxe/values.yaml
+targetfile: kubernetes/cray-tftpd-ipxe/templates/nf_nat_tftp.yaml
+


### PR DESCRIPTION
## Summary and Scope

On fanta, it was discovered that a new SLES provided kernel, deployed as part of CSM, was unable to boot nodes because the tftpd dameon replicaset that injected kernel modules into all worker nodes was failing. The reason, is that the host OS/kernel had switched to zlib compressed kernel modules, and the version of modprobe within alpine:3/busybox does not support this.

The fix is to switch the replicaset to use the same busybox based alpine3 base image that is used by tftp daemon itself (also built on alpine3/busybox), but apk add an updated kmod to it to allow it the ability to insmod/modprobe inject zlib compressed kernel modules.

## Issues and Related PRs

* Resolves [CASMTRIAGE-4761](https://jira-pro.its.hpecorp.net:8443/browse/CASMTRIAGE-4763)

## Testing

The image was built using our normal CI deployment workflow. I downloaded a copy of the chart and the resultant built image and verified that the new image had a zlib compatible modprobe binary in it, and that the chart replicaset had the appropriately templated image name saved within it.

### Tested on:

  * Local development environment

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Target branch correct
- [X] CHANGELOG.md updated
