### PR TITLE
Release/1.10.0

### DIFF
--- a/.github/workflows/license-check.yaml
+++ b/.github/workflows/license-check.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.9.0] - 2024-02-23
 ### Changed
 - Disabled concurrent Jenkins builds on same branch/commit
 - Added build timeout to avoid hung builds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.10.0] - 2024-04-29
 ### Changed
 - Update cray-tftp-ipxe chart to work with CSM 1.6 manifests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update cray-tftp-ipxe chart to work with CSM 1.6 manifests
 
 ### Dependencies
 - Bump `tj-actions/changed-files` from 42 to 44 ([#60](https://github.com/Cray-HPE/cms-tftpd/pull/60), [#61](https://github.com/Cray-HPE/cms-tftpd/pull/61))

--- a/kubernetes/cray-tftpd-ipxe/Chart.yaml
+++ b/kubernetes/cray-tftpd-ipxe/Chart.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -30,7 +30,7 @@ sources:
 - "https://github.com/Cray-HPE/cms-tftpd"
 dependencies:
 - name: cray-service
-  version: "^7.0.0"
+  version: "~10.0"
   repository: "https://artifactory.algol60.net/artifactory/csm-helm-charts/"
 maintainers:
 - name: jsl-hpe

--- a/kubernetes/cray-tftpd-ipxe/templates/clusterrole.yaml
+++ b/kubernetes/cray-tftpd-ipxe/templates/clusterrole.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+(C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -38,3 +38,4 @@ rules:
   - get
   - list
   - watch
+  - patch

--- a/kubernetes/cray-tftpd-ipxe/templates/configmap-bss-aarch64.yaml
+++ b/kubernetes/cray-tftpd-ipxe/templates/configmap-bss-aarch64.yaml
@@ -1,0 +1,135 @@
+{{/*
+MIT License
+
+(C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/}}
+{{- $root := . -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cray-ipxe-bss-ipxe-aarch64
+  labels:
+    app.kubernetes.io/name: {{ .Values.ipxe.name }}
+data:
+  bss.ipxe: >
+    #!ipxe
+
+    echo Chaining to BSS ...
+
+    set attempt:int16 0
+
+    set maxattempts:int16 {{ .Values.ipxe.bss_max_attempts }}
+
+    set sleepytime:int8 0
+
+    set ceiling:int8 {{ .Values.ipxe.bss_ceiling }}
+
+    :start
+
+    inc attempt
+
+    inc sleepytime
+
+    iseq ${sleepytime} ${ceiling} && set sleepytime:int32 {{ 1 | sub .Values.ipxe.bss_ceiling }} ||
+
+    iseq ${attempt} ${maxattempts} && goto debug_retry ||
+
+    echo Chain attempt ${attempt} of ${maxattempts}
+
+    echo Hint: Press CTRL+C to skip a network interface
+
+    # Iterate through all of the available network interfaces, starting with nic_index_vip.
+
+    :dhcpstart
+
+    set vidx:int8 {{ .Values.ipxe.nic_index_vip }}
+
+    # If the VIP index does not exist, then default to 0. This is useful for systems with less NICs than what the default VIP index is set for.
+
+    isset ${net${vidx}/mac} || set vidx:int8 0
+
+    :dhcpcheck isset ${net${vidx}/mac} || goto retry
+
+      # Attempt to use the NIC.
+
+      ifclose net${vidx} || echo Failed to close net${vidx}
+
+      sync
+
+      ifopen net${vidx} || echo Failed to open net${vidx}
+
+      ifconf -c dhcp net${vidx} && goto configured || ifclose net${vidx}
+    
+      # Increment our index and continue.
+
+      # The VIP index indicates which network interface to try first, before iterating through the
+
+      # remainder of the interfaces starting with interface zero. For example, a VIP index of 2 
+
+      # would start with 2 and then proceed through net0, net1, net3, netX before wrapping around
+
+      # back to net2 once all of the available NICs were exhausted.
+
+      # If our index is 0, increment and continue. Skip all other funny business.
+
+      iseq ${vidx} 0 && inc vidx && goto dhcpcheck ||
+    
+      # Else, if our current index is 1 less than the starting index, then set the index to 1 after the starting index.
+
+      iseq ${vidx} {{ sub .Values.ipxe.nic_index_vip 1 }} && set vidx:int8 {{ .Values.ipxe.nic_index_vip | add1 }} && goto dhcpcheck ||
+
+      # Else, if our current index is equal to our start index, start over at 0. Otherwise increment by one.
+
+      iseq ${vidx} {{ .Values.ipxe.nic_index_vip }} && set vidx:int8 0 || inc vidx && goto dhcpcheck
+
+      # Else, just plainly increment the index.
+
+      inc vidx && goto dhcpcheck
+
+    :configured
+
+    echo net${vidx} IPv4 lease: ${net${vidx}/ip} MAC: ${net${vidx}/mac}
+
+    chain --timeout {{ $root.Values.ipxe.chain_timeout }} http{{ if $root.Values.ipxe.build_with_cert }}s{{ end }}://{{ $root.Values.ipxe.api_gw }}/apis/bss/boot/v1/bootscript?mac=${net${vidx}/mac} || echo Failed to retrieve next chain from Boot Script Service over net${vidx} (http{{ if $root.Values.ipxe.build_with_cert }}s{{ end }}://{{ $root.Values.ipxe.api_gw }}/apis/bss/boot/v1/bootscript?mac=${net${vidx}/mac}) && goto start 
+
+    ifclose net${vidx} || echo No routes to drop.
+
+    :retry
+
+    echo Failed to fetch boot script!
+
+    echo Retrying in ${sleepytime} seconds ... (CTRL+C to skip)
+
+    sleep ${sleepytime} ||
+
+    goto start
+
+    :debug_retry
+
+    echo IPXE failed to retrieve next chain after ${maxattempts} attempts or was interrupted.
+
+    goto debug
+
+    :debug
+
+    echo (type 'exit' to drop into BIOS).
+
+    shell

--- a/kubernetes/cray-tftpd-ipxe/templates/configmap-settings.yaml
+++ b/kubernetes/cray-tftpd-ipxe/templates/configmap-settings.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+(C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -29,7 +29,21 @@ metadata:
     app.kubernetes.io/name: {{ .Values.ipxe.name }}
 data:
   settings.yaml: |
-    cray_ipxe_build_x86: {{ .Values.ipxe.build_x86 }}
-    cray_ipxe_build_bss: {{ .Values.ipxe.build_bss }}
-    cray_ipxe_build_shell: {{ .Values.ipxe.build_shell }}
+    # Global build options
+    cray_ipxe_token_host: {{ .Values.ipxe.api_gw }}
+    cray_ipxe_token_min_remaining_valid_time: {{ .Values.ipxe.token_min_remaining_valid_time }}
     cray_ipxe_build_with_cert: {{ .Values.ipxe.build_with_cert }}
+    cray_ipxe_build_service_log_level : {{ .Values.ipxe.build_service_log_level }}
+    cray_ipxe_build_kind: {{ .Values.ipxe.build_kind }}
+
+    # x86_64 build options
+    cray_ipxe_build_x86: {{ .Values.ipxe.build_x86 }}
+    cray_ipxe_binary_name: {{ .Values.ipxe.cray_ipxe_binary_name }}
+    cray_ipxe_debug_enabled: {{ .Values.ipxe.build_x86_debug }}
+    cray_ipxe_debug_binary_name: {{ .Values.ipxe.cray_ipxe_debug_binary_name }}
+
+    # aarch64 build options
+    cray_ipxe_aarch64_enabled: {{ .Values.ipxe.build_aarch64 }}
+    cray_ipxe_aarch64_binary_name: {{ .Values.ipxe.cray_ipxe_aarch64_binary_name }}
+    cray_ipxe_aarch64_debug_enabled : {{ .Values.ipxe.build_aarch64_debug }}
+    cray_ipxe_aarch64_debug_binary_name: {{ .Values.ipxe.cray_ipxe_aarch64_debug_binary_name }}

--- a/kubernetes/cray-tftpd-ipxe/templates/hmn-tftp-service.yml
+++ b/kubernetes/cray-tftpd-ipxe/templates/hmn-tftp-service.yml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -26,13 +26,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: cray-tftpd-hmn
+  name: cray-tftp-hmn
   labels:
     app.kubernetes.io/name: {{ include "cray-service.name" $crayServiceValues }}
     app.kubernetes.io/instance: {{ include "cray-service.name" $crayServiceValues }}
   annotations:
     metallb.universe.tf/address-pool: hardware-management
-    cray.io/service: cray-tftpd
+    cray.io/service: cray-tftp
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Cluster

--- a/kubernetes/cray-tftpd-ipxe/templates/nmn-tftp-service.yml
+++ b/kubernetes/cray-tftpd-ipxe/templates/nmn-tftp-service.yml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -26,13 +26,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: cray-tftpd-nmn
+  name: cray-tftp-nmn
   labels:
     app.kubernetes.io/name: {{ include "cray-service.name" $crayServiceValues }}
     app.kubernetes.io/instance: {{ include "cray-service.name" $crayServiceValues }}
   annotations:
     metallb.universe.tf/address-pool: node-management
-    cray.io/service: cray-tftpd
+    cray.io/service: cray-tftp
 spec:
   type: LoadBalancer
   externalTrafficPolicy: Cluster

--- a/kubernetes/cray-tftpd-ipxe/values.yaml
+++ b/kubernetes/cray-tftpd-ipxe/values.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -35,7 +35,7 @@ hmn_tftp_service_ip: "10.94.100.60"
 
 cray-service:
   type: Deployment
-  nameOverride: cray-tftpd-ipxe
+  nameOverride: cray-tftp-ipxe
   serviceAccountName: cray-ipxe
   priorityClassName: csm-high-priority-service
   podAnnotations:
@@ -48,7 +48,7 @@ cray-service:
           - key: app
             operator: In
             values:
-            - cray-tftpd-ipxe
+            - cray-tftp-ipxe
         topologyKey: "kubernetes.io/hostname"
   replicaCount: 3
   containers:
@@ -80,6 +80,10 @@ cray-service:
       image:
         repository: artifactory.algol60.net/csm-docker/stable/cray-bss-ipxe
         tag: IMAGE_CRAY_BSS_IPXE_TAG
+      command:
+        - python3
+        - "-m"
+        - "crayipxe.builds.x86-64"
       volumeMounts:
       - name: cray-tftp-data
         mountPath: /shared_tftp
@@ -90,6 +94,8 @@ cray-service:
       - name: ca-public-key
         mountPath: /ca_public_key
       env:
+      - name: LOG_LEVEL
+        value: INFO
       - name: IPXE_BUILD_TIME_LIMIT
         value: "40"
       - name: DEBUG_IPXE_BUILD_TIME_LIMIT
@@ -102,7 +108,8 @@ cray-service:
           - crayipxe.liveness
         initialDelaySeconds: 40
         periodSeconds: 40
-
+      securityContext:
+        runAsNonRoot: true
   volumes:
     - name: cray-tftp-data
       emptyDir: {}
@@ -122,25 +129,20 @@ cray-service:
 ipxe:
   name: cray-ipxe
   namespace: services
-  image_version: "latest"
+
+  # These settings influence the creation of the bss ipxe script; these settings apply to multiple architecture builders.
+  build_service_log_level: INFO
 
   # Override with networks['node_management'].api_gw_service_dnsname
   api_gw: api-gw-service-nmn.local
+  build_with_cert: true
+  # If a token is going to expire within this number of seconds, update it.
+  token_min_remaining_valid_time: 1800
 
   # The following are options that pertain to the build environment; checking in
   # values here change the resultant number of build environments that are created
   # as a response to updates or changes in the environment.
-  build_bss: true
-  build_shell: true
   chain_timeout: 10000
-
-  # The following are options that pertain to which architectures are built for
-  # the ipxe flavors that are listed above.
-  build_x86: true
-
-  # The following are options that pertain to how the ipxe binaries are built with
-  # relation to embedding public CA certificates into images.
-  build_with_cert: true
 
   # The following are options that pertain to the resultant interfaces that are
   # allowed as booting devices. By default, the resultant ipxe binary will instruct
@@ -153,12 +155,12 @@ ipxe:
   # Overall time incurred on network miss depends on dhcp configuration on the
   # network attached to the NICs, but is about 10 seconds per failed network try.
   nic_boot_order:
-    - net2
-    - net0
-    - net1
-    - net3
-    - net4
-    - net5
+  - net2
+  - net0
+  - net1
+  - net3
+  - net4
+  - net5
 
   bss_max_attempts: 1024
 
@@ -180,3 +182,20 @@ ipxe:
   # represents the pathological maximum to boot; in reality nothing should ever get
   # this high.
   bss_ceiling: 64
+
+  # The build_kind variable controls the overall buildout of the binaries for all builders, and defaults to 'ipxe'. This
+  # allows the builders to change effective behavior for the kinds of artifacts that are eventually built out to further
+  # support kpxe/undionly variants.
+  build_kind: ipxe
+
+  # These options are specific to x86_64 ipxe builds
+  build_x86: true
+  cray_ipxe_binary_name: ipxe.efi
+  build_x86_debug: true
+  cray_ipxe_debug_binary_name: debug-ipxe.efi
+
+  # These options are specific to aarch64/arm64 ipxe builds
+  build_aarch64: true
+  cray_ipxe_aarch64_binary_name: ipxe.arm64.efi
+  build_aarch64_debug: true
+  cray_ipxe_aarch64_debug_binary_name: debug-ipxe.arm64.efi

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -39,4 +39,4 @@
 
 image: cray-bss-ipxe
     major: 1
-    minor: 11
+    minor: 12


### PR DESCRIPTION
## Summary and Scope
Release 1.10.0
    - Fix cms-tftp-ipxe chart
    - Bump tj-actions/changed-files to 44

## Issues and Related PRs
* Resolves [CASMCMS-8107](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8107)
* Resolves [CASMCMS-8889](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8889)

## Testing
Previously tested with manual chart patching on a Mercury machine
### Tested on:

  * Mercury

### Test description:
Patched chart successfully deployed and pods entered Running state

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations
The cray-tftp-ipxe chart changes only apply to Mercury systems

## Pull Request Checklist
- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
